### PR TITLE
add spark support

### DIFF
--- a/README.md
+++ b/README.md
@@ -62,6 +62,8 @@ mesoscope regions input.json
 
 This will create a file `image-input.tif` showing the regions. Type `mesoscope regions -h` to see other options. If given a 2d image `--image` the regions will be overlayed onto it. If given another set of regions `--compare` and a `--threshold` then the `precision`, `recall`, and `inclusion`, `exclusion` scores will be calculated and saved. The hits (green) and misses (red) will also be plotted saved as an image.
 
+For all commands, the option `--spark spark://xx.xx.xx:7077` allows you to specify a Spark cluster to use via the URL of its master node.
+
 # use as a module
 
 The `mesoscope` package includes the following methods

--- a/README.md
+++ b/README.md
@@ -62,7 +62,7 @@ mesoscope regions input.json
 
 This will create a file `image-input.tif` showing the regions. Type `mesoscope regions -h` to see other options. If given a 2d image `--image` the regions will be overlayed onto it. If given another set of regions `--compare` and a `--threshold` then the `precision`, `recall`, and `inclusion`, `exclusion` scores will be calculated and saved. The hits (green) and misses (red) will also be plotted saved as an image.
 
-For all commands, the option `--spark spark://xx.xx.xx:7077` allows you to specify a Spark cluster to use via the URL of its master node.
+For all commands, the option `--master spark://xxxxx:7077` allows you to specify a Spark cluster master node by providing the URL of the master node. When using this option, any paths to input and output folders should be given with full path names.
 
 # use as a module
 

--- a/mesoscope/commands/common.py
+++ b/mesoscope/commands/common.py
@@ -1,0 +1,22 @@
+import click
+
+def success(msg):
+    click.echo('[' + click.style('success', fg='green') + '] ' + msg)
+
+def status(msg):
+    click.echo('[' + click.style('convert', fg='blue') + '] ' + msg)
+
+def error(msg):
+    click.echo('[' + click.style('error', fg='red') + '] ' + msg)
+
+def warn(msg):
+    click.echo('[' + click.style('warn', fg='yellow') + '] ' + msg)
+
+def setup_spark(master):
+    if master:
+        status('configuring spark cluster')
+        from pyspark import SparkContext
+        context = SparkContext(master=master)
+        return context
+    else:
+        return None

--- a/mesoscope/commands/convert.py
+++ b/mesoscope/commands/convert.py
@@ -6,6 +6,7 @@ from numpy import inf
 from glob import glob
 from shutil import rmtree
 from os.path import join, isdir
+from .common import success, status, error
 from .. import load, convert
 
 @click.option('--overwrite', is_flag=True, help='Overwrite if directory already exists')
@@ -43,12 +44,3 @@ def convert_command(input, output, ext, overwrite):
     with open(join(output, 'metadata.json'), 'w') as f:
       f.write(json.dumps(newmeta, indent=2))
     success('data written')
-
-def success(msg):
-    click.echo('[' + click.style('success', fg='green') + '] ' + msg)
-
-def status(msg):
-    click.echo('[' + click.style('convert', fg='blue') + '] ' + msg)
-
-def error(msg):
-    click.echo('[' + click.style('error', fg='red') + '] ' + msg)

--- a/mesoscope/commands/extract.py
+++ b/mesoscope/commands/extract.py
@@ -5,6 +5,7 @@ from os.path import join, isfile, isdir, dirname, splitext, basename
 from skimage.io import imsave, imread
 from showit import image
 from extraction import load
+from .common import success, status, error, warn
 from ..models import compare as compareModels
 from ..models import overlay
 
@@ -19,15 +20,3 @@ def extract_command(input, output, diameter, method, overwrite):
 
 
     success('extract complete')
-
-def success(msg):
-    click.echo('[' + click.style('success', fg='green') + '] ' + msg)
-
-def status(msg):
-    click.echo('[' + click.style('convert', fg='blue') + '] ' + msg)
-
-def error(msg):
-    click.echo('[' + click.style('error', fg='red') + '] ' + msg)
-
-def warn(msg):
-    click.echo('[' + click.style('warn', fg='yellow') + '] ' + msg)

--- a/mesoscope/commands/regions.py
+++ b/mesoscope/commands/regions.py
@@ -5,6 +5,7 @@ from os.path import join, isfile, isdir, dirname, splitext, basename
 from skimage.io import imsave, imread
 from showit import image
 from extraction import load
+from .common import success, status, error, warn
 from ..models import compare as compareModels
 from ..models import overlay
 
@@ -56,15 +57,3 @@ def regions_command(input, output, image, compare, threshold, overwrite):
         warn('%s already exists and overwrite is false' % name)
 
     success('regions complete')
-
-def success(msg):
-    click.echo('[' + click.style('success', fg='green') + '] ' + msg)
-
-def status(msg):
-    click.echo('[' + click.style('convert', fg='blue') + '] ' + msg)
-
-def error(msg):
-    click.echo('[' + click.style('error', fg='red') + '] ' + msg)
-
-def warn(msg):
-    click.echo('[' + click.style('warn', fg='yellow') + '] ' + msg)

--- a/mesoscope/commands/summarize.py
+++ b/mesoscope/commands/summarize.py
@@ -9,6 +9,7 @@ from os.path import join, isdir, isfile
 from thunder.images import fromtif, frombinary
 from skimage.io import imsave
 from .. import downsample
+from .common import success, status, error, warn
 from showit import image
 import matplotlib.animation as animation
 import matplotlib.pyplot as plt
@@ -141,15 +142,3 @@ def summarize_command(input, output, localcorr, mean, movie, ds, dt, size, overw
             warn('%s already exists and overwrite is false' % name)
 
     success('summary complete')
-
-def success(msg):
-    click.echo('[' + click.style('success', fg='green') + '] ' + msg)
-
-def status(msg):
-    click.echo('[' + click.style('convert', fg='blue') + '] ' + msg)
-
-def error(msg):
-    click.echo('[' + click.style('error', fg='red') + '] ' + msg)
-
-def warn(msg):
-    click.echo('[' + click.style('warn', fg='yellow') + '] ' + msg)

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,7 @@
 thunder-python >= 1.4.2
 thunder-registration >= 1.0.1
+thunder-extraction >= 1.2.1
 click >= 6.6
 showit >= 1.1.1
+regional >= 1.1.2
+neurofinder-python >= 1.1.1


### PR DESCRIPTION
This PR adds support for specifying a Spark master URL via the command line tool. The option was only added for the `register` command but the core bits are in a function inside `commands/common.py` that could be used by other functions where desired. While I was at it I moved the status messaging bits to `common.py` as well.

Finally, there were additional dependencies not listed in `requirements.txt` that were required to get the CLI to run, so I added those. One remaining one I wasn't sure how to add, `single_cell_detect`, but I seem to remember you were thinking of maybe just inlining that function.